### PR TITLE
Add links to badges

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -23,41 +23,41 @@ Dusk unlocks economic opportunities for all by making institutional-level financ
 ## Main repositories
 
 * [`dusk-blockchain`](https://github.com/dusk-network/dusk-blockchain): reference implementation of the Dusk Network node\
-![dusk-network/dusk-blockchain last commit](https://img.shields.io/github/last-commit/dusk-network/dusk-blockchain)
-![dusk-network/dusk-blockchain issues](https://img.shields.io/github/issues-raw/dusk-network/dusk-blockchain)
-![dusk-network/dusk-blockchain pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/dusk-blockchain)
+[![dusk-network/dusk-blockchain last commit](https://img.shields.io/github/last-commit/dusk-network/dusk-blockchain)](https://github.com/dusk-network/dusk-blockchain/commits/master)
+[![dusk-network/dusk-blockchain issues](https://img.shields.io/github/issues-raw/dusk-network/dusk-blockchain)](https://github.com/dusk-network/dusk-blockchain/issues)
+[![dusk-network/dusk-blockchain pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/dusk-blockchain)](https://github.com/dusk-network/dusk-blockchain/pulls)
 
 * [`rusk`](https://github.com/dusk-network/rusk): Dusk's smart contract platform \
-![dusk-network/rusk last commit](https://img.shields.io/github/last-commit/dusk-network/rusk)
-![dusk-network/rusk issues](https://img.shields.io/github/issues-raw/dusk-network/rusk)
-![dusk-network/rusk pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/rusk)
+[![dusk-network/rusk last commit](https://img.shields.io/github/last-commit/dusk-network/rusk)](https://github.com/dusk-network/rusk/commits/master)
+[![dusk-network/rusk issues](https://img.shields.io/github/issues-raw/dusk-network/rusk)](https://github.com/dusk-network/rusk/issues)
+[![dusk-network/rusk pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/rusk)](https://github.com/dusk-network/rusk/pulls)
 
 * [`wallet-cli`](https://github.com/dusk-network/wallet-cli): Dusk wallet CLI and library\
-![dusk-network/wallet-cli last commit](https://img.shields.io/github/last-commit/dusk-network/wallet-cli)
-![dusk-network/wallet-cli issues](https://img.shields.io/github/issues-raw/dusk-network/wallet-cli)
-![dusk-network/wallet-cli pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/wallet-cli)
+[![dusk-network/wallet-cli last commit](https://img.shields.io/github/last-commit/dusk-network/wallet-cli)](https://github.com/dusk-network/wallet-cli/commits/main)
+[![dusk-network/wallet-cli issues](https://img.shields.io/github/issues-raw/dusk-network/wallet-cli)](https://github.com/dusk-network/wallet-cli/issues)
+[![dusk-network/wallet-cli pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/wallet-cli)](https://github.com/dusk-network/wallet-cli/pulls)
 
 * [`itn-installer`](https://github.com/dusk-network/itn-installer): installer to run a Dusk Network node for our ITN program\
-![dusk-network/itn-installer last commit](https://img.shields.io/github/last-commit/dusk-network/itn-installer)
-![dusk-network/itn-installer issues](https://img.shields.io/github/issues-raw/dusk-network/itn-installer)
-![dusk-network/itn-installer pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/itn-installer)
+[![dusk-network/itn-installer last commit](https://img.shields.io/github/last-commit/dusk-network/itn-installer)](https://github.com/dusk-network/itn-installer/commits/main)
+[![dusk-network/itn-installer issues](https://img.shields.io/github/issues-raw/dusk-network/itn-installer)](https://github.com/dusk-network/itn-installer/issues)
+[![dusk-network/itn-installer pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/itn-installer)](https://github.com/dusk-network/itn-installer/pulls)
 
 * [`dusk-ui-kit`](https://github.com/dusk-network/dusk-ui-kit): Dusk UI component library \
-![dusk-network/dusk-ui-kit last commit](https://img.shields.io/github/last-commit/dusk-network/dusk-ui-kit)
-![dusk-network/dusk-ui-kit issues](https://img.shields.io/github/issues-raw/dusk-network/dusk-ui-kit)
-![dusk-network/dusk-ui-kit pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/dusk-ui-kit)
+[![dusk-network/dusk-ui-kit last commit](https://img.shields.io/github/last-commit/dusk-network/dusk-ui-kit)](https://github.com/dusk-network/dusk-ui-kit/commits/main)
+[![dusk-network/dusk-ui-kit issues](https://img.shields.io/github/issues-raw/dusk-network/dusk-ui-kit)](https://github.com/dusk-network/dusk-ui-kit/issues)
+[![dusk-network/dusk-ui-kit pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/dusk-ui-kit)](https://github.com/dusk-network/dusk-ui-kit/pulls)
 
 ## Libraries
 
 * [`plonk`](https://github.com/dusk-network/plonk): Rust implementation of the PLONK ZKProof System, done by the Dusk Network team \
-![dusk-network/plonk last commit](https://img.shields.io/github/last-commit/dusk-network/plonk)
-![dusk-network/plonk issues](https://img.shields.io/github/issues-raw/dusk-network/plonk)
-![dusk-network/plonk pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/plonk)
+[![dusk-network/plonk last commit](https://img.shields.io/github/last-commit/dusk-network/plonk)](https://github.com/dusk-network/plonk/commits/master)
+[![dusk-network/plonk issues](https://img.shields.io/github/issues-raw/dusk-network/plonk)](https://github.com/dusk-network/plonk/issues)
+[![dusk-network/plonk pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/plonk)](https://github.com/dusk-network/plonk/pulls)
 
 * [`kadcast`](https://github.com/dusk-network/kadcast): Rust implementation of the Kadcast P2P protocol, done by the Dusk Network team  \
-![dusk-network/kadcast last commit](https://img.shields.io/github/last-commit/dusk-network/kadcast)
-![dusk-network/kadcast issues](https://img.shields.io/github/issues-raw/dusk-network/kadcast)
-![dusk-network/kadcast pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/kadcast)
+[![dusk-network/kadcast last commit](https://img.shields.io/github/last-commit/dusk-network/kadcast)](https://github.com/dusk-network/kadcast/commits/main)
+[![dusk-network/kadcast issues](https://img.shields.io/github/issues-raw/dusk-network/kadcast)](https://github.com/dusk-network/kadcast/issues)
+[![dusk-network/kadcast pull requests](https://img.shields.io/github/issues-pr-raw/dusk-network/kadcast)](https://github.com/dusk-network/kadcast/pulls)
 
 
 ## Contributing


### PR DESCRIPTION
This PR makes the badge images (last commit, issues, PRs, etc...) link to the corresponding page.

New page here: https://github.com/dusk-network/.github/tree/fix-21/profile

Fixes #21 