### PR TITLE
Make reusable workflows more flexible

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,29 +9,36 @@ on: [pull_request, push]
 name: Dusk CI
 
 jobs:
-  # Import the localized workflow
+  # Import the reusable workflow to use Clippy and Rustfmt
   analyze:
     name: Code Analysis
-    uses: ./.github/workflows/code-analysis.yml
+    uses: dusk-network/.github/.github/workflows/code-analysis.yml@main
 
-  # It's possible to import workflows from elsewhere
-  # that have been marked as `on: workflow_call:`
-  test:
-    name: Nightly tests
-    uses: https://github.com/dusk-network/.github/.github/workflows/nightly-test.yml
+  # Import the Dusk analyzer workflow to check for license markings etc.
+  analyze:
+    name: Dusk Analyzer
+    uses: dusk-network/.github/.github/workflows/dusk-analysis.yml@main
 
-  # It's still possible to introduce your own jobs if
-  # the workflows specified above do not fit your repos
-  # complexities.
-  test_nightly_no_std:
-      name: Nightly tests no_std
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3
-        - uses: dtolnay/rust-toolchain@nightly
-          with:
-            components: clippy
-        - uses: Swatinem/rust-cache@v2
-        - run: cargo test --release --no-default-features
+  # The `run-tests` workflow has a couple of configuration options.
+  # The defaults should be enough to run tests for release and uses
+  # the Rust nightly toolchain.
+  test_nightly_std:
+    name: Nightly release tests
+    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
+
+  # The toolchain and test flags are passible though:
+  test_stable_no_std:
+    name: Stable no_std tests
+    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
+    with:
+      rust_toolchain: stable
+      test_flags: --no-default-features
+
+  # In case the repository needs to enable specific features:
+  test_nightly_features:
+    name: Nightly specific features tests
+    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
+    with:
+      test_flags: --features=feature1,feature2
 
 ```

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -4,19 +4,9 @@ on:
 name: Code Analysis
 
 jobs:
-  dusk_analyzer:
-    name: Dusk Analyzer
-    runs-on: [self-hosted]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo install --git https://github.com/dusk-network/cargo-dusk-analyzer
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo dusk-analyzer
-
   rustfmt:
     name: Rust Format
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
@@ -27,7 +17,7 @@ jobs:
 
   clippy:
     name: Clippy Check
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/dusk-analysis.yml
+++ b/.github/workflows/dusk-analysis.yml
@@ -1,16 +1,15 @@
 on:
   workflow_call:
 
-name: Nightly Tests
+name: Dusk Analysis
 
 jobs:
-  nightly_tests:
-    name: Nightly tests
+  dusk_analyzer:
+    name: Dusk Analyzer
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: clippy
+      - run: cargo install --git https://github.com/dusk-network/cargo-dusk-analyzer
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --release
+      - run: cargo dusk-analyzer

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,27 @@
+on:
+  workflow_call:
+    inputs:
+      rust_toolchain:
+        description: 'Rust toolchain version'
+        required: true
+        type: string
+        default: nightly
+      test_flags:
+        description: 'Additional flags for cargo test'
+        required: false
+        type: string
+        default: ''
+
+name: Tests
+
+jobs:
+  tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@${{ inputs.rust_toolchain }}
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --release ${{ inputs.test_flags }}


### PR DESCRIPTION
This commit contains the following changes:
- Fix 'self-hosted', since no jobs are being picked up.
- Split Dusk Analyzer from Code Analysis, since not every repo will be able to use it.
- Make the original nightly tests workflow more flexible by allowing the toolchain and test flags to be passable parameters.