### PR TITLE
Remove workflow toolchain

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,35 +10,31 @@ name: Dusk CI
 
 jobs:
   # Import the reusable workflow to use Clippy and Rustfmt
-  analyze:
+  code_analysis:
     name: Code Analysis
     uses: dusk-network/.github/.github/workflows/code-analysis.yml@main
 
   # Import the Dusk analyzer workflow to check for license markings etc.
-  analyze:
+  dusk_analysis:
     name: Dusk Analyzer
     uses: dusk-network/.github/.github/workflows/dusk-analysis.yml@main
 
-  # The `run-tests` workflow has a couple of configuration options.
-  # The defaults should be enough to run tests for release and uses
-  # the Rust nightly toolchain.
-  test_nightly_std:
-    name: Nightly release tests
-    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
-
-  # The toolchain and test flags are passible though:
-  test_stable_no_std:
-    name: Stable no_std tests
+  # Test flags are passable to `run-tests`:
+  test_no_std:
+    name: no_std tests
     uses: dusk-network/.github/.github/workflows/run-tests.yml@main
     with:
-      rust_toolchain: stable
       test_flags: --no-default-features
 
   # In case the repository needs to enable specific features:
-  test_nightly_features:
-    name: Nightly specific features tests
+  test_features:
+    name: Specific features tests
     uses: dusk-network/.github/.github/workflows/run-tests.yml@main
     with:
       test_flags: --features=feature1,feature2
 
 ```
+
+## Toolchain
+
+To set the toolchain for the workflows, specify a `rust-toolchain` or `rust-toolchain.toml` file.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,9 +10,14 @@ name: Dusk CI
 
 jobs:
   # Import the reusable workflow to use Clippy and Rustfmt
+  # Rustfmt is ran with the nightly toolchain by default due to nice features
+  # not being stable yet. The toolchain type and version is, however, passable to the 
+  # workflow file.
   code_analysis:
     name: Code Analysis
     uses: dusk-network/.github/.github/workflows/code-analysis.yml@main
+  # with:
+  #   toolchain: stable
 
   # Import the Dusk analyzer workflow to check for license markings etc.
   dusk_analysis:

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,5 +1,11 @@
 on:
   workflow_call:
+    inputs:
+      rust_toolchain:
+        description: 'Rust toolchain version'
+        required: true
+        type: string
+        default: nightly
 
 name: Code Analysis
 
@@ -9,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
-          components: rustfmt 
+          components: rustfmt
+          toolchain: ${{ inputs.rust_toolchain }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 
@@ -20,8 +27,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-features --release -- -D warnings

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      rust_toolchain:
+      toolchain:
         description: 'Rust toolchain version'
         required: true
         type: string
@@ -18,7 +18,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: ${{ inputs.rust_toolchain }}
+          toolchain: ${{ inputs.toolchain }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 

--- a/.github/workflows/dusk-analysis.yml
+++ b/.github/workflows/dusk-analysis.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
       - run: cargo install --git https://github.com/dusk-network/cargo-dusk-analyzer
       - uses: Swatinem/rust-cache@v2
       - run: cargo dusk-analyzer

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,11 +1,6 @@
 on:
   workflow_call:
     inputs:
-      rust_toolchain:
-        description: 'Rust toolchain version'
-        required: true
-        type: string
-        default: nightly
       test_flags:
         description: 'Additional flags for cargo test'
         required: false
@@ -20,8 +15,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@${{ inputs.rust_toolchain }}
-        with:
-          components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --release ${{ inputs.test_flags }}


### PR DESCRIPTION
Remove the toolchain action, under the assumption that Rust is already available on the target system and the rust-toolchain file will be picked up automatically.

For `Rustfmt`, some repositories use nightly features, like `wrap_comments`. Given it's a great feature to have, and `Rustfmt` being nightly is not a big risk, `Rustfmt` is set to nightly by default but settable if the consumer of the workflow wishes to use a specific version or the stable toolchain.