### PR TITLE
Allow passable args to clippy workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,11 +13,23 @@ jobs:
   # Rustfmt is ran with the nightly toolchain by default due to nice features
   # not being stable yet. The toolchain type and version is, however, passable to the 
   # workflow file.
+  #
+  # The default clippy configuration might be too strict for certain repositories.
+  # The `clippy_default` parameter is set to true and will execute:
+  # `cargo clippy --all-features --release -- -D warnings
+  #
+  # If it is set to false and an empty `clippy_args` argument is passed, 
+  # `cargo clippy` will be executed.
+  #
+  # If arguments are passed with `clippy_args` while `clippy_default` is set to
+  # false, `cargo clippy {clippy_args}` will be ran.
   code_analysis:
     name: Code Analysis
     uses: dusk-network/.github/.github/workflows/code-analysis.yml@main
   # with:
   #   toolchain: stable
+  #   clippy_default: true
+  #   clippy_args: ''
 
   # Import the Dusk analyzer workflow to check for license markings etc.
   dusk_analysis:

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -5,6 +5,15 @@ on:
         description: 'Rust toolchain version'
         type: string
         default: nightly
+      clippy_default:
+        description: 'Use default arguments'
+        type: boolean
+        required: false
+        default: true
+      clippy_args:
+        description: 'Custom arguments for Clippy'
+        type: string
+        required: false
 
 name: Code Analysis
 
@@ -33,4 +42,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-features --release -- -D warnings
+      - run: |
+          if [ ${{ inputs.clippy_default }} == true ]; then
+            cargo clippy --all-features --release -- -D warnings
+          elif [ -z "${{ inputs.clippy_default }}" ]; then
+            cargo clippy
+          else
+            cargo clippy ${{ inputs.clippy_args }}
+          fi


### PR DESCRIPTION
The current structure makes Clippy pretty inflexible in repositories where we might need custom arguments to be passed. 

This change allows for the user of the workflow to be more specific than the pretty stringent default.