### PR TITLE
Run tests workflow optional Rust target

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,12 +43,13 @@ jobs:
     with:
       test_flags: --no-default-features
 
-  # In case the repository needs to enable specific features:
+  # In case the repository needs to enable specific features or requires a Rust target installed:
   test_features:
     name: Specific features tests
     uses: dusk-network/.github/.github/workflows/run-tests.yml@main
     with:
       test_flags: --features=feature1,feature2
+      rust_target: wasm32-unknown-unknown
 
 ```
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,6 +6,10 @@ on:
         required: false
         type: string
         default: ''
+      rust_target:
+        description: 'Optional Rust target'
+        required: false
+        type: string
 
 name: Tests
 
@@ -15,5 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install Optional Rust Target
+        if: ${{ inputs.rust_target }}
+        run: rustup target add ${{ inputs.rust_target }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --release ${{ inputs.test_flags }}
+      - name: Execute Tests
+        run: cargo test --release ${{ inputs.test_flags }}


### PR DESCRIPTION
Adds an optional Rust target flag to the `run-tests` reusable workflow.

This change is both backward and forward compatible.