### PR TITLE
Use setup-rust-toolchain to manage toolchains

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: core
     steps:
       - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: rustup override set ${{ inputs.toolchain }}
-      - uses: Swatinem/rust-cache@v2
       - run: |
           if [ "${{ inputs.toolchain }}" == "nightly" ]; then
             cargo +nightly fmt --all -- --check
@@ -37,7 +37,7 @@ jobs:
     runs-on: core
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: |
           if [ ${{ inputs.clippy_default }} == true ]; then
             cargo clippy --all-features --release -- -D warnings

--- a/.github/workflows/dusk-analysis.yml
+++ b/.github/workflows/dusk-analysis.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: core
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo install --git https://github.com/dusk-network/cargo-dusk-analyzer
       - run: cargo dusk-analyzer

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: core
     steps:
       - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Optional Rust Target
         if: ${{ inputs.rust_target }}
         run: rustup target add ${{ inputs.rust_target }}
-      - uses: Swatinem/rust-cache@v2
       - name: Execute Tests
         run: cargo test --release ${{ inputs.test_flags }}


### PR DESCRIPTION
Our current reusable workflow assume that the underlying system comes with Rust installed.

Situations might arise where the `$HOME/.cargo/bin` folder might be purged on a clean toolchain install, which leads to `rustup` no longer being available system-wide. The newly introduced `setup-rust-toolchain` action has a fallback mechanism built-in that reinstalls `rustup` in case it's not available anymore.