### PR TITLE
Optimize reusable workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 This workflows directory contains the most commonly used workflow jobs within our organization. These workflows are reusable and can be imported into other workflow files. For more information see the Github article on [Reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows).
 
-By default, the workflows use `core` runners. These are self-hosted runners in a Linux Ubuntu environment. If you run into a `startup failure` error with these runners, be sure to enable the self-hosted runners said repository and allow external actions to be executed.
+By default, the workflows use `core` runners. These are self-hosted runners in a Linux Ubuntu environment. If you run into a `startup failure` error with these runners, be sure to enable the self-hosted runners for the repository and allow external actions to be executed. Repositories can override the default runner label with the reusable workflow `runner` input.
 
 Example:
 ```yaml
@@ -11,8 +11,9 @@ on: [pull_request, push]
 name: Dusk CI
 
 jobs:
-  # Import the reusable workflow to use Clippy and Rustfmt
-  # Rustfmt is ran with the toolchain specified in the `rust-tooolchain.toml` file.
+  # Import the reusable workflow to use Clippy and Rustfmt.
+  # Rustfmt runs first inside the same job as Clippy, using the toolchain
+  # specified in the `rust-toolchain.toml` file.
   #
   # The default clippy configuration might be too strict for certain repositories.
   # The `clippy_default` parameter is set to true and will execute:
@@ -27,8 +28,10 @@ jobs:
     name: Code Analysis
     uses: dusk-network/.github/.github/workflows/code-analysis.yml@main
   # with:
+  #   runner: core
   #   clippy_default: true
   #   clippy_args: ''
+  #   enable_sccache: true
 
   # Import the Dusk analyzer workflow to check for license markings etc.
   #
@@ -40,6 +43,7 @@ jobs:
     name: Dusk Analyzer
     uses: dusk-network/.github/.github/workflows/dusk-analysis.yml@main
     with:
+      runner: core
       working-directory: ./app
 
   # Test flags are passable to `run-tests`:
@@ -47,15 +51,19 @@ jobs:
     name: no_std tests
     uses: dusk-network/.github/.github/workflows/run-tests.yml@main
     with:
+      runner: core
       test_flags: --no-default-features
+      # enable_sccache: true
 
   # In case the repository needs to enable specific features or requires a Rust target installed:
   test_features:
     name: Specific features tests
     uses: dusk-network/.github/.github/workflows/run-tests.yml@main
     with:
+      runner: core
       test_flags: --features=feature1,feature2
       rust_target: wasm32-unknown-unknown
+      # enable_sccache: true
 
   # Import cargo-deny checks.
   # The selected working directory must contain deny.toml.
@@ -63,12 +71,14 @@ jobs:
     name: Cargo Deny
     uses: dusk-network/.github/.github/workflows/cargo-deny.yml@main
     with:
+      runner: core
       working-directory: ./app
       deny-check-args: --all-features
+      # enable_sccache: true
 
 ```
 
-## Toolchain
+## Toolchain And Cache
 
 To set the toolchain for the workflows, usage of `rust-toolchain.toml` is recommended. For certain channels, toolchain components like `clippy` and `rustfmt` are not available by default. This is problematic when using the `code_analysis` workflow. The following example config is therefore recommended:
 ```toml
@@ -76,3 +86,5 @@ To set the toolchain for the workflows, usage of `rust-toolchain.toml` is recomm
 channel = "nightly"
 components = ["clippy", "rustfmt"]
 ```
+
+When `enable_sccache` is left at its default value, the reusable Rust workflows automatically set `RUSTC_WRAPPER` if `sccache` is available on the runner and emit `sccache -s` at the end of the job. This keeps cache usage visible without making hosted runners fail if `sccache` is absent.

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        description: "Runner label or image"
+        required: false
+        type: string
+        default: core
       working-directory:
         description: "Project directory where Cargo.toml and deny.toml are located"
         required: false
@@ -11,19 +16,33 @@ on:
         required: false
         type: string
         default: ""
+      enable_sccache:
+        description: "Enable sccache automatically when it is available on the runner"
+        required: false
+        type: boolean
+        default: true
 
 name: Cargo Deny
 
 jobs:
   cargo_deny:
     name: Cargo Deny
-    runs-on: core
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Enable sccache
+        if: ${{ inputs.enable_sccache }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v sccache >/dev/null; then
+            echo "RUSTC_WRAPPER=$(command -v sccache)" >> "$GITHUB_ENV"
+          fi
 
       - name: Install cargo-deny
         run: cargo install --locked cargo-deny
@@ -40,3 +59,10 @@ jobs:
       - name: Run cargo-deny checks
         working-directory: ${{ inputs.working-directory }}
         run: cargo deny check ${{ inputs.deny-check-args }}
+      - name: sccache stats
+        if: ${{ always() && inputs.enable_sccache }}
+        shell: bash
+        run: |
+          if command -v sccache >/dev/null; then
+            sccache -s || true
+          fi

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        description: 'Runner label or image'
+        type: string
+        required: false
+        default: core
       clippy_default:
         description: 'Use default arguments'
         type: boolean
@@ -10,29 +15,56 @@ on:
         description: 'Custom arguments for Clippy'
         type: string
         required: false
+      enable_sccache:
+        description: 'Enable sccache automatically when it is available on the runner'
+        type: boolean
+        required: false
+        default: true
 
 name: Code Analysis
 
 jobs:
-  rustfmt:
-    name: Rust Format
-    runs-on: core
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dsherret/rust-toolchain-file@v1
-      - run: cargo fmt --all -- --check
-
   clippy:
     name: Clippy Check
-    runs-on: core
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
-      - run: |
-          if [ ${{ inputs.clippy_default }} == true ]; then
+      - name: Enable sccache
+        if: ${{ inputs.enable_sccache }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v sccache >/dev/null; then
+            echo "RUSTC_WRAPPER=$(command -v sccache)" >> "$GITHUB_ENV"
+          fi
+      - name: Run rustfmt
+        run: cargo fmt --all -- --check
+      - name: Run Clippy
+        shell: bash
+        env:
+          CLIPPY_DEFAULT: ${{ inputs.clippy_default }}
+          CLIPPY_ARGS: ${{ inputs.clippy_args }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$CLIPPY_DEFAULT" == "true" ]]; then
             cargo clippy --all-features --release -- -D warnings
-          elif [ -z "${{ inputs.clippy_default }}" ]; then
+            exit 0
+          fi
+
+          if [[ -z "${CLIPPY_ARGS}" ]]; then
             cargo clippy
-          else
-            cargo clippy ${{ inputs.clippy_args }}
+            exit 0
+          fi
+
+          clippy_args=()
+          read -r -a clippy_args <<< "$CLIPPY_ARGS"
+          cargo clippy "${clippy_args[@]}"
+      - name: sccache stats
+        if: ${{ always() && inputs.enable_sccache }}
+        shell: bash
+        run: |
+          if command -v sccache >/dev/null; then
+            sccache -s || true
           fi

--- a/.github/workflows/dusk-analysis.yml
+++ b/.github/workflows/dusk-analysis.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: core
       working-directory:
         required: false
         type: string
@@ -13,7 +17,7 @@ jobs:
     name: Dusk Analyzer
     # Checks for valid MPL license header in source code files
     # Checks for git dependency pinning
-    runs-on: core
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        description: 'Runner label or image'
+        required: false
+        type: string
+        default: core
       test_flags:
         description: 'Additional flags for cargo test'
         required: false
@@ -10,18 +15,56 @@ on:
         description: 'Optional Rust target'
         required: false
         type: string
+      enable_sccache:
+        description: 'Enable sccache automatically when it is available on the runner'
+        required: false
+        type: boolean
+        default: true
 
 name: Tests
 
 jobs:
   tests:
     name: Run tests
-    runs-on: core
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
+      - name: Enable sccache
+        if: ${{ inputs.enable_sccache }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v sccache >/dev/null; then
+            echo "RUSTC_WRAPPER=$(command -v sccache)" >> "$GITHUB_ENV"
+          fi
       - name: Install Optional Rust Target
         if: ${{ inputs.rust_target }}
-        run: rustup target add ${{ inputs.rust_target }}
+        shell: bash
+        env:
+          RUST_TARGET: ${{ inputs.rust_target }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RUST_TARGET" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid rust target '$RUST_TARGET'"
+            exit 1
+          fi
+          rustup target add "$RUST_TARGET"
       - name: Execute Tests
-        run: cargo test --release ${{ inputs.test_flags }}
+        shell: bash
+        env:
+          TEST_FLAGS: ${{ inputs.test_flags }}
+        run: |
+          set -euo pipefail
+          test_args=()
+          if [[ -n "$TEST_FLAGS" ]]; then
+            read -r -a test_args <<< "$TEST_FLAGS"
+          fi
+          cargo test --release "${test_args[@]}"
+      - name: sccache stats
+        if: ${{ always() && inputs.enable_sccache }}
+        shell: bash
+        run: |
+          if command -v sccache >/dev/null; then
+            sccache -s || true
+          fi


### PR DESCRIPTION
This PR adds:
- `sccache` and runner optionality into the workflows
- Enables `sccache` by default
- Moves `rustfmt` into the clippy check to reduce number of active jobs and build minute round up waste