### PR TITLE
Upgrade actions/checkout from v4.3.1 to v6.0.2

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -39,7 +39,7 @@ jobs:
     if: ${{ inputs.runner != 'core' || inputs.allow_fork_pr_on_core || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.runner != 'core' || inputs.allow_fork_pr_on_core || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1

--- a/.github/workflows/dusk-analysis.yml
+++ b/.github/workflows/dusk-analysis.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.runner != 'core' || inputs.allow_fork_pr_on_core || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1

--- a/.github/workflows/run-make.yml
+++ b/.github/workflows/run-make.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.runner != 'core' || inputs.allow_fork_pr_on_core || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Add Rust tools to PATH

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.runner != 'core' || inputs.allow_fork_pr_on_core || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1


### PR DESCRIPTION
Upgrade `actions/checkout` from v4.3.1 to v6.0.2 for all reusable workflows.