### PR TITLE
Add hardened reusable JavaScript CI workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -102,6 +102,74 @@ jobs:
 
 ```
 
+## JavaScript / TypeScript Workflows
+
+The reusable npm workflows follow the same hardening defaults as the Rust
+workflows:
+- They run with `permissions: contents: read`.
+- `actions/checkout` uses `persist-credentials: false`.
+- Third-party actions are pinned to immutable commit SHAs.
+- The default runner is `core`.
+- For `pull_request` events, fork PR jobs are blocked on `core` by default.
+
+Callers should pin reusable workflow refs to immutable commit SHAs instead of
+mutable branches such as `main`.
+
+### npm CI
+
+Use `npm-ci.yml` for repositories that install with `npm ci` and validate via
+package scripts.
+
+```yaml
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+name: CI
+
+jobs:
+  lint_test:
+    name: Validate & build
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    uses: dusk-network/.github/.github/workflows/npm-ci.yml@<full_commit_sha>
+    with:
+      runner: ubuntu-latest
+      node-version-file: .nvmrc
+      run_sveltekit_sync: true
+      # For repositories without .nvmrc, pass node-version instead:
+      # node-version: 22.11.0
+      # To customize validation, pass the npm scripts to run:
+      # scripts: |
+      #   format
+      #   lint
+      #   typecheck
+      #   test
+      #   build:storybook
+      # pack_dry_run: true
+      # codecov_files: coverage/lcov.info
+```
+
+Examples:
+- `docs`: pass `node-version: 22.12.0` and `scripts: build`.
+- `web-wallet` and `explorer`: pass `runner: ubuntu-latest`,
+  `node-version-file: .nvmrc`, and `run_sveltekit_sync: true`.
+- `stox-frontend`: pass `node-version: 22.11.0`.
+- `stox-admin-ui`: pass `node-version: 24` and `scripts` containing
+  `db:generate`, `format`, `typecheck`, and `test`.
+- `duskit`: pass `node-version: 22.15.0` and `scripts` containing
+  `format:check`, `lint`, `typecheck`, `test:coverage`, `build`, and
+  `build:storybook`.
+- `connect`: pass `node-version: 24`, `scripts: ci`, and
+  `pack_dry_run: true`.
+- `wallet`: pass `node-version: 24`, `scripts` containing `test:coverage`,
+  `build:chrome`, and `build:firefox`, plus
+  `codecov_files: coverage/lcov.info`.
+
 ## Toolchain And Cache
 
 To set the toolchain for the workflows, usage of `rust-toolchain.toml` is recommended. For certain channels, toolchain components like `clippy` and `rustfmt` are not available by default. This is problematic when using the `code_analysis` workflow. The following example config is therefore recommended:

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -1,0 +1,207 @@
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'Runner label or image'
+        required: false
+        type: string
+        default: core
+      working-directory:
+        description: 'Relative working directory that contains package.json'
+        required: false
+        type: string
+        default: .
+      node-version:
+        description: 'Node.js version to install. Leave empty to use node-version-file.'
+        required: false
+        type: string
+        default: ''
+      node-version-file:
+        description: 'Relative path to a Node.js version file'
+        required: false
+        type: string
+        default: .nvmrc
+      cache-dependency-path:
+        description: 'Relative path to the npm lockfile used for setup-node cache'
+        required: false
+        type: string
+        default: package-lock.json
+      run_sveltekit_sync:
+        description: 'Run `npm exec -- svelte-kit sync` before validation'
+        required: false
+        type: boolean
+        default: false
+      scripts:
+        description: 'Newline-separated npm scripts to run after install'
+        required: false
+        type: string
+        default: |
+          format
+          lint
+          typecheck
+          test
+          build
+      pack_dry_run:
+        description: 'Run `npm pack --dry-run` after all npm scripts'
+        required: false
+        type: boolean
+        default: false
+      codecov_files:
+        description: 'Optional coverage file list for Codecov upload'
+        required: false
+        type: string
+        default: ''
+      codecov_fail_ci_if_error:
+        description: 'Fail CI when Codecov upload fails'
+        required: false
+        type: boolean
+        default: false
+      allow_fork_pr_on_core:
+        description: 'Allow execution on fork pull_request events when using core runners'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+name: npm CI
+
+permissions:
+  contents: read
+
+jobs:
+  npm_ci:
+    name: Validate npm project
+    runs-on: ${{ inputs.runner }}
+    if: ${{ inputs.runner != 'core' || inputs.allow_fork_pr_on_core || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate inputs
+        shell: bash
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          NODE_VERSION: ${{ inputs.node-version }}
+          NODE_VERSION_FILE: ${{ inputs.node-version-file }}
+          CACHE_DEPENDENCY_PATH: ${{ inputs.cache-dependency-path }}
+          NPM_SCRIPTS: ${{ inputs.scripts }}
+        run: |
+          set -euo pipefail
+
+          validate_relative_path() {
+            local value="$1"
+            local name="$2"
+
+            if [[ -z "$value" ]]; then
+              echo "::error::$name must not be empty"
+              exit 1
+            fi
+            if [[ "$value" == /* ]]; then
+              echo "::error::$name must be relative"
+              exit 1
+            fi
+            if [[ "$value" =~ (^|/)\.\.(/|$) ]]; then
+              echo "::error::$name must stay within the repository"
+              exit 1
+            fi
+          }
+
+          validate_script_name() {
+            local value="$1"
+            local name="$2"
+
+            if [[ -n "$value" && ! "$value" =~ ^[A-Za-z0-9][A-Za-z0-9:._@/-]*$ ]]; then
+              echo "::error::Invalid npm script name for $name: '$value'"
+              exit 1
+            fi
+          }
+
+          validate_relative_path "$WORKING_DIRECTORY" "working-directory"
+          validate_relative_path "$CACHE_DEPENDENCY_PATH" "cache-dependency-path"
+
+          if [[ -n "$NODE_VERSION_FILE" ]]; then
+            validate_relative_path "$NODE_VERSION_FILE" "node-version-file"
+          fi
+
+          if [[ -n "$NODE_VERSION" && ! "$NODE_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid node-version '$NODE_VERSION'"
+            exit 1
+          fi
+
+          while IFS= read -r script; do
+            [[ -z "$script" ]] && continue
+            validate_script_name "$script" "scripts"
+          done <<< "$NPM_SCRIPTS"
+
+          if [[ ! -d "$WORKING_DIRECTORY" ]]; then
+            echo "::error::Working directory '$WORKING_DIRECTORY' does not exist"
+            exit 1
+          fi
+          if [[ ! -f "$WORKING_DIRECTORY/package.json" ]]; then
+            echo "::error::package.json not found in '$WORKING_DIRECTORY'"
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        if: ${{ inputs.node-version != '' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}/${{ inputs.cache-dependency-path }}
+
+      - name: Set up Node.js from version file
+        if: ${{ inputs.node-version == '' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ${{ inputs.working-directory }}/${{ inputs.node-version-file }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}/${{ inputs.cache-dependency-path }}
+
+      - name: Install dependencies
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          set -euo pipefail
+          npm ci
+
+      - name: Sync SvelteKit config
+        if: ${{ inputs.run_sveltekit_sync }}
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          set -euo pipefail
+          npm exec -- svelte-kit sync
+
+      - name: Run npm scripts
+        if: ${{ inputs.scripts != '' }}
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          NPM_SCRIPTS: ${{ inputs.scripts }}
+        run: |
+          set -euo pipefail
+
+          while IFS= read -r script; do
+            [[ -z "$script" ]] && continue
+            npm run "$script"
+          done <<< "$NPM_SCRIPTS"
+
+      - name: Upload coverage to Codecov
+        if: ${{ inputs.codecov_files != '' }}
+        uses: codecov/codecov-action@0f8570b1a125f4937846a11fcfa3bcd548bd8c97 # v4.6.0
+        with:
+          files: ${{ inputs.working-directory }}/${{ inputs.codecov_files }}
+          fail_ci_if_error: ${{ inputs.codecov_fail_ci_if_error }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Validate package contents
+        if: ${{ inputs.pack_dry_run }}
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          set -euo pipefail
+          npm pack --dry-run


### PR DESCRIPTION
Adds reusable hardened CI workflows for JavaScript and TypeScript projects, matching the security properties of the existing Rust reusable workflows. NPM based projects with configurable scripts like format, lint, typecheck, test and build can use `npm-ci.yml`.